### PR TITLE
Rename package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Protractor Template",
+  "name": "protractor-template",
   "version": "1.0.1",
   "description": "Template to implement e2e test in AngularJS",
   "main": "index.js",


### PR DESCRIPTION
## したこと
- `pacakge.json`のnameを編集。
## なぜ
- nameに空白があると環境によってはnpm installが走らないため。
